### PR TITLE
Se corrije la migracion dato 39

### DIFF
--- a/database/migrations/2023_03_29_041329_create_dato39s_table.php
+++ b/database/migrations/2023_03_29_041329_create_dato39s_table.php
@@ -20,9 +20,9 @@ return new class extends Migration
             $table->string('TIPODEDOCUMENTO')->nullable();
             $table->string('CEDULA')->nullable();
             $table->string('NOMBRE')->nullable();
-            $table->string('DIRECCIÓN')->nullable();
+            $table->string('DIRECCION')->nullable();
             $table->string('TAG')->nullable();
-            $table->string('MATRÍCULA')->nullable();
+            $table->string('MATRICULA')->nullable();
             $table->string('TEL1')->nullable();
             $table->string('TEL2')->nullable();
             $table->string('TEL3')->nullable();


### PR DESCRIPTION
Se realizan correcciones de la migracion dato 39 donde se tenia dos variables con tildes, se corrige y se carga al repo.